### PR TITLE
Generic embedding handling with byte-safe serialization

### DIFF
--- a/src/EmbeddingDocumentBase.cs
+++ b/src/EmbeddingDocumentBase.cs
@@ -8,12 +8,33 @@ namespace VectorIndexScenarioSuite
         public string Id { get; set; }
 
         [JsonProperty(PropertyName = "embedding")]
-        public int[] Embedding { get; }
+        public Array Embedding { get; }
 
         public EmbeddingDocumentBase(string id, T[] embedding)
         {
             this.Id = id;
-            this.Embedding = Array.ConvertAll(embedding, item => Convert.ToInt32(item));
+            this.Embedding = ToJsonFriendlyArray(embedding);
+        }
+
+        private static Array ToJsonFriendlyArray(T[] embedding)
+        {
+            // byte[] and sbyte[] are serialized as base64 strings by default. Convert
+            // them to an int array so that each element is represented as a number
+            // in JSON instead of a base64 encoded string.
+            if (typeof(T) == typeof(byte))
+            {
+                var bytes = (byte[])(object)embedding;
+                return Array.ConvertAll(bytes, static b => (int)b);
+            }
+
+            if (typeof(T) == typeof(sbyte))
+            {
+                var sbytes = (sbyte[])(object)embedding;
+                return Array.ConvertAll(sbytes, static b => (int)b);
+            }
+
+            // For other numeric types (e.g. float), no conversion is required.
+            return embedding;
         }
     }
 }

--- a/src/EmbeddingScearioBase.cs
+++ b/src/EmbeddingScearioBase.cs
@@ -204,8 +204,8 @@ namespace VectorIndexScenarioSuite
             // Issue parallel queries to all partitions, capping this to MAX_PHYSICAL_PARTITION_COUNT but can be override through config.
             int overrideMaxConcurrancy = Convert.ToInt32(this.Configurations["AppSettings:scenario:MaxPhysicalPartitionCount"]);
             int maxConcurrancy = overrideMaxConcurrancy == 0 ? this.MaxPhysicalPartitionCount : overrideMaxConcurrancy;
-            await foreach ((int vectorId, byte[] vector, string whereClause) in
-                JsonDocumentFactory<byte>.GetQueryAsync(dataPath, 0 /* startVectorId */, numQueries, this.IsFilterSearch))
+            await foreach ((int vectorId, T[] vector, string whereClause) in
+                JsonDocumentFactory<T>.GetQueryAsync(dataPath, 0 /* startVectorId */, numQueries, this.IsFilterSearch))
             {
 
                 var queryDefinition = ConstructQueryDefinition(KVal, vector, whereClause);
@@ -283,19 +283,34 @@ namespace VectorIndexScenarioSuite
             }
         }
 
-        // HARD CODED FOR BYTE
-        private QueryDefinition ConstructQueryDefinition(int K, byte[] queryVector, string whereClause)
+        private static Array ToJsonFriendlyArray(T[] vector)
+        {
+            if (typeof(T) == typeof(byte))
+            {
+                var bytes = (byte[])(object)vector;
+                return Array.ConvertAll(bytes, static b => (int)b);
+            }
+
+            if (typeof(T) == typeof(sbyte))
+            {
+                var sbytes = (sbyte[])(object)vector;
+                return Array.ConvertAll(sbytes, static b => (int)b);
+            }
+
+            return vector;
+        }
+
+        private QueryDefinition ConstructQueryDefinition(int K, T[] queryVector, string whereClause)
         {
             int searchListSizeMultiplier = Convert.ToInt32(this.Configurations["AppSettings:scenario:searchListSizeMultiplier"]);
 
-            int[] queryVectorInt = queryVector.Select(b => (int)b)
-                .ToArray();
+            object vectorEmbeddingParam = ToJsonFriendlyArray(queryVector);
+
             // empty json object for using default value if multiplier is 0
             string obj_expr = searchListSizeMultiplier == 0 ? "{}" : $"{{ 'searchListSizeMultiplier': {searchListSizeMultiplier} }}";
             string queryText = $"SELECT TOP {K} c.id, VectorDistance(c.{this.EmbeddingColumn}, @vectorEmbedding) AS similarityScore " +
                 $"FROM c {whereClause} ORDER BY VectorDistance(c.{this.EmbeddingColumn}, @vectorEmbedding, false, {obj_expr})";
-            return new QueryDefinition(queryText).WithParameter("@vectorEmbedding", queryVectorInt);
-
+            return new QueryDefinition(queryText).WithParameter("@vectorEmbedding", vectorEmbeddingParam);
         }
 
         private string GetBaseDataPath()


### PR DESCRIPTION
## Summary
- Convert byte and sbyte vectors to int arrays via helper to avoid base64 JSON encoding
- Reuse helper when constructing query definitions so float vectors remain unchanged

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689a5204e3d88328b00f240b8b83b81f